### PR TITLE
Remove trailing space from interpreter directive

### DIFF
--- a/roffit
+++ b/roffit
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl 
+#!/usr/bin/env perl
 #
 # roffit: convert man page source files to HTML
 #


### PR DESCRIPTION
Because msysgit env chokes on the trailing space.