### PR TITLE
Fix output of text in pre tags

### DIFF
--- a/roffit
+++ b/roffit
@@ -80,7 +80,6 @@ sub defaultcss {
 <STYLE type="text/css">
 pre {
   overflow: auto;
-  border: 1px solid #aaa;
   margin: 0;
 }
 

--- a/roffit
+++ b/roffit
@@ -473,14 +473,15 @@ sub parsefile {
             # replace backslash [something] with just [something]
             $txt =~ s/\\(.)/$1/g;
 
-            if($txt =~ /^[ \t\r\n]*$/) {
+            if(($txt =~ /^[ \t\r\n]*$/) && (!$pre)) {
                 # no contents, marks end of a paragraph
                 showp(@p);
                 @p="";
             }
             else {
                 $txt =~ s/^ /\&nbsp\;/g;
-                push @p, "$txt ";
+                push @p, "$txt";
+                push @p, " " if(!$pre);
             }
             $out ="";
         }

--- a/roffit
+++ b/roffit
@@ -78,6 +78,12 @@ sub showp {
 sub defaultcss {
     print $OutFH <<ENDOFCSS
 <STYLE type="text/css">
+pre {
+  overflow: auto;
+  border: 1px solid #aaa;
+  margin: 0;
+}
+
 P.level0, pre.level0 {
  padding-left: 2em;
 }

--- a/roffit
+++ b/roffit
@@ -71,22 +71,22 @@ while($ARGV[0]) {
 
 sub showp {
     my @p = @_;
-    push @out, "\n" if(!$pre);
-    push @out, "<p class=\"level$indentlevel\">", @p;
+    push @out, "\n<p class=\"level$indentlevel\">" if(!$pre);
+    push @out, @p;
 }
 
 sub defaultcss {
     print $OutFH <<ENDOFCSS
 <STYLE type="text/css">
-P.level0 {
+P.level0, pre.level0 {
  padding-left: 2em;
 }
 
-P.level1 {
+P.level1, pre.level1 {
  padding-left: 4em;
 }
 
-P.level2 {
+P.level2, pre.level2 {
  padding-left: 6em;
 }
 
@@ -333,7 +333,7 @@ sub parsefile {
 
                 showp(@p);
                 @p="";
-                push @out, "<pre>\n";
+                push @out, "<pre class=\"level$indentlevel\">\n";
                 $pre=1
             }
             elsif($keyword =~ /^TP$/i) {


### PR DESCRIPTION
I didn't squash these together because I'm not sure which if any you want and also if they are separate it will be easier to revert if there's a problem with one.

`roffit: Fix bad formatting in pre tags`
First commit is to fix bad formatting in the `<pre>` tags. The issue is evident on the libcurl doc pages online, for example [libcurl-multi.3](http://curl.haxx.se/libcurl/c/libcurl-multi.html#BLOCKING). Each subsequent line of text in a pre tag has an erroneous leading space. Additionally empty "no content" lines use a `<p>` rather than just appending the line to the output. The latter isn't apparent visually but it is incorrect.

`roffit: Change pre tag indent formatting method`
Second commit is so that `<pre>` tags are indented using their own class (ie `<pre class="level0">`) rather than nesting a `<p class="level0">` in the pre tag. As I noted in the commit message visually I can see no difference but the [W3C checker says nesting in a p tag to make the indent is incorrect](http://validator.w3.org/check?uri=curl.haxx.se%2Flibcurl%2Fc%2Flibcurl-multi.html%23BLOCKING).

`roffit: Handle text length overflow in pre tags`
Third commit is pretty much as it says. I don't know enough about this tool's usage in practice to know whether text in pre could overflow the browser window but generally speaking it's sometimes a problem with code in pre tags. I also added a border in this commit to distinguish the pre area since I thought it looked better to have a border when there could be a horizontal scroll bar.
<br>

The first commit I think is needed, the second and third I don't know. Visually the third commit may not be appealing with the border since end users will be used to it without and pre isn't used just for code.

Also, you'll notice the text in pre tags still renders slightly to the left of other text (regardless of whether or not you apply my changes) and that is because for padding roffit uses the css em unit which is relative to font size, and since browser fonts used for pre are often different from their regular fonts the spacing offset doesn't match up. To solve this another length unit could be used, maybe, but I really don't know what would line everything up exactly. I can't spend any more time on it, but if you want I'll open an issue so there is a record.
