### PR TITLE
Support .ti (temporary indent) tag

### DIFF
--- a/roffit
+++ b/roffit
@@ -513,6 +513,9 @@ sub parsefile {
                     }
                 }
             }
+            elsif ($keyword =~ /^ti/i) {
+                push @p, "&nbsp;&nbsp;&nbsp;&nbsp;";
+            }
             else {
                 showp(@p);
                 @p="";


### PR DESCRIPTION
`.ti` is a "temporary indent" that affects the next line of text only. It takes an argument, the width to indent. This change simply treats all `.ti` instructions as a 4-space indent of the next line by injecting 4 non-breaking space entities (`&nbsp;`). Example manpages that use this tag are `pcap_loop.3pcap` and `pcap_dispatch.3pcap` from the-tcpdump-group/libpcap