### PR TITLE
Avoid nesting pre tags when multiple .nf directives are used

### DIFF
--- a/roffit
+++ b/roffit
@@ -387,8 +387,11 @@ sub parsefile {
 
                 showp(@p);
                 @p="";
-                push @out, "<pre class=\"level$indentlevel\">\n";
-                $pre=1
+                if (!$pre) {
+                    # avoid nesting pre sections
+                    push @out, "<pre class=\"level$indentlevel\">\n";
+                    $pre=1
+                }
             }
             elsif($keyword =~ /^TP$/i) {
                 # Used within an "RS" section to make a new line. The first


### PR DESCRIPTION
Some man page sources were using multiple .nf lines without intervening
paragraph markers or .fi that would otherwise tell us to end the
no-fill. If we're already in a pre section, don't start a new one.