### PR TITLE
Avoid unhandled font face tags in .IP elements

### DIFF
--- a/roffit
+++ b/roffit
@@ -407,6 +407,7 @@ sub parsefile {
                 $anchor{$name}=1;
 
                 $rest =~ s/\"//g; # cut off quotes
+		$rest =~ s/\\f[IBPR]//g; # Un-format it (Use CSS on nroffip class instead)
                 $rest = do_encode($rest);
                 
                 $indentlevel-- if ($indentlevel);


### PR DESCRIPTION
The indented paragraph designator can be formatted with CSS; there's not
a reason to handle special font faces here, so those directives were
being rendered in plain text. Remove them entirely.