### PR TITLE
roffit: strip italic corrections

### DIFF
--- a/roffit
+++ b/roffit
@@ -559,6 +559,9 @@ sub parsefile {
             # \e is the "escape character", defaults to backslash
             $txt =~ s/\\e/&bsol;/g;
 
+            # \/ and \, are "italic corrections" that we can just remove
+            $txt =~ s/\\[,\/]//g;
+
             $txt = handle_italic_bold $txt;
 
             # replace backslash [something] with just [something]

--- a/testpage.1
+++ b/testpage.1
@@ -5,7 +5,8 @@
 .SH NAME
 testpage \- test input nroff man page for roffit testing
 .SH SYNOPSIS
-.B roffit [options] < inputfile > outputfile
+.B roffit
+[\fI\,options\/\fR] < inputfile > outputfile
 .SH DESCRIPTION
 .B roffit
 converts the \fIinputfile\fP to \fIoutputfile\fP. The \fIinputfile\fP must be

--- a/testpage.output
+++ b/testpage.output
@@ -2,7 +2,7 @@
 
 <p class="level0"><a name="NAME"></a><h2 class="nroffsh">Name</h2>
 <p class="level0">testpage - test input nroff man page for roffit testing <a name="SYNOPSIS"></a><h2 class="nroffsh">Synopsis</h2>
-<p class="level0"><span Class="bold">roffit [options] &lt; inputfile &gt; outputfile</span> <a name="DESCRIPTION"></a><h2 class="nroffsh">Description</h2>
+<p class="level0"><span Class="bold">roffit</span> [<span Class="emphasis">options</span>] &lt; inputfile &gt; outputfile <a name="DESCRIPTION"></a><h2 class="nroffsh">Description</h2>
 <p class="level0"><span Class="bold">roffit</span> converts the <span Class="emphasis">inputfile</span> to <span Class="emphasis">outputfile</span>. The <span Class="emphasis">inputfile</span> must be an nroff formatted man page, and the <span Class="emphasis">outputfile</span> will be an HTML document. 
 <p class="level0"><a href="http://www.ietf.org/rfc/rfc959.txt">RFC 959</a> is FTP 
 <p class="level0"><a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a> is URI syntax 


### PR DESCRIPTION
The `\/` escape sequence inserts an italic correction, i.e. a small piece of horizontal motion (1/12 em) that should be sufficient to separate an italic character from a following roman character. Similarly, `\,`, adds a left italic correction, always a zero motion, that should be sufficient to separate a roman character from an immediately following italic character.

roffit now simply removes them

Fixes #28