### PR TITLE
roffit: Decrease the indent level for .PP

### DIFF
--- a/roffit
+++ b/roffit
@@ -502,6 +502,7 @@ sub parsefile {
                 $within_tp=0;
                 showp(@p);
                 @p="";
+                $indentlevel-- if ($indentlevel);
             }
             elsif($keyword =~ /^fi$/i) {
                 # .fi = fill-in, extra space will be ignored and text that is


### PR DESCRIPTION
Prior to this change when .PP (regular paragraph) was used after .IP (indented paragraph) roffit would not change the indent level which resulted in regular paragraphs having the same indent as the previously indented paragraph.

Ref: https://github.com/curl/curl/issues/13803#issuecomment-2135857895

Closes #xxxxx

---

![website2](https://github.com/curl/curl/assets/965580/6189ac48-668f-4dd9-8a2c-4b2928f107a5)

I can't figure out if we should reset it like `$indentlevel = 0` or just decrease it but in testing just decreasing seems to work as expected.
