### PR TITLE
make: switch to install and copy manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,12 +16,15 @@
 #
 ##########################################################################
 # default installation directory
-INSTALLDIR=/usr/local/bin
+PREFIX=/usr/local
+BINDIR=$(PREFIX)/bin
+MANDIR=$(PREFIX)/man
 
 all:
 
 install:
-	cp roffit $(DESTDIR)$(INSTALLDIR)
+	install -Dm0755 roffit $(DESTDIR)$(BINDIR)/roffit
+	install -Dm0644 roffit.1 $(DESTDIR)$(MANDIR)/man1/roffit.1
 
 test:
 	@perl roffit --bare < testpage.1 > testpage.dump


### PR DESCRIPTION
- use `install` instead of `cp` to create leading directories should they not yet exist
- install manpage to have documentation present along with the binary