### PR TITLE
roffit: add --man option for better external linking

### DIFF
--- a/roffit
+++ b/roffit
@@ -257,7 +257,6 @@ sub linkfile {
                                     # there is such a HTML file present, produce a
                                     # link to it!
                                     $link = "<a Class=\"$style\" href=\"$html\">$symbol</a>";
-                                    $found = 1;
                                     last; # skip out of loop
                                 }
                             }

--- a/roffit
+++ b/roffit
@@ -21,7 +21,7 @@
 #
 # Web:     https://daniel.haxx.se/projects/roffit
 
-my $version = "0.17";
+my $version = "0.18";
 
 use strict;
 #use warnings;
@@ -50,6 +50,7 @@ my $mandir;
 my $hrefdir=".";
 my $filename;
 my $leavecase;
+my %manhref;
 
 while($ARGV[0]) {
     if($ARGV[0] eq "--bare") {
@@ -64,6 +65,14 @@ while($ARGV[0]) {
     elsif($ARGV[0] eq "--preserve-case") {
         $leavecase = 1;
         exit;
+    }
+    elsif($ARGV[0] =~ /^--man=([^=]*)=(.*)/) {
+        # check for other man pages in the given dir, and if so, link to it
+        # using the second string. can be specified multiple times
+        push @mandirs, $1;
+        $manhref{$1} = $2;
+        $mandir = 1; # option used
+        shift @ARGV;
     }
     elsif($ARGV[0] =~ /^--mandir=(.*)/) {
         # check for other HTMLized man pages in these given dirs
@@ -84,6 +93,8 @@ while($ARGV[0]) {
             " --bare          do not put in HTML, HEAD, BODY tags\n",
             " --hrefdir=<dir> if a manpage is found in the --mandir, this is the\n",
             "                 dir we prefix the HTML file name with in the output\n",
+            " --man=<dir>=<href> if a manpage is found in DIR then link to it using\n",
+            "                 HREF\n",
             " --mandir=<dir>  check for other HTMLized man pages in these dirs\n",
             " --preserve-case leave case of section headers untouched\n",
             " --version       display roffit version and exit\n";
@@ -238,10 +249,15 @@ sub linkfile {
                                 my $file = "$d/$symbol.$section";
 
                                 if(-r $file) {
-                                    my $html = "$hrefdir/$symbol.html";
+                                    my $href = $hrefdir;
+                                    if($manhref{$d}) {
+                                        $href = $manhref{$d};
+                                    }
+                                    my $html = "$href/$symbol.html";
                                     # there is such a HTML file present, produce a
                                     # link to it!
                                     $link = "<a Class=\"$style\" href=\"$html\">$symbol</a>";
+                                    $found = 1;
                                     last; # skip out of loop
                                 }
                             }


### PR DESCRIPTION
This new option accepts two directories. The first is where (prefix) to look for an existing man page soruce file. If that exists, it uses the second prefix to prepend to the genrated HTML file name when creating a link to it.